### PR TITLE
Revert to original stringify params method

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -852,14 +852,11 @@ abstract class AmazonCore{
      * @return string
      */
     protected function _getParametersAsString(array $parameters) {
-//        $queryParameters = array();
-//        foreach ($parameters as $key => $value) {
-//            $queryParameters[] = $key . '=' . $this->_urlencode($value);
-//        }
-//        return implode('&', $queryParameters);
-
-        // We may as well use the input method!
-        return http_build_query($parameters);
+        $queryParameters = array();
+        foreach ($parameters as $key => $value) {
+            $queryParameters[] = $key . '=' . $this->_urlencode($value);
+        }
+        return implode('&', $queryParameters);
     }
     
     /**

--- a/includes/classes/AmazonFeed.php
+++ b/includes/classes/AmazonFeed.php
@@ -28,22 +28,22 @@ class AmazonFeed extends AmazonFeedsCore{
     protected $response;
     protected $feedContent;
     protected $feedMD5;
-    
+
     /**
      * AmazonFeed submits a Feed to Amazon.
-     * 
+     *
      * The parameters are passed to the parent constructor, which are
      * in turn passed to the AmazonCore constructor. See it for more information
      * on these parameters and common methods.
-     * @param string $s [optional] <p>Name for the store you want to use.
-     * This parameter is optional if only one store is defined in the config file.</p>
      * @param boolean $mock [optional] <p>This is a flag for enabling Mock Mode.
      * This defaults to <b>FALSE</b>.</p>
      * @param array|string $m [optional] <p>The files (or file) to use in Mock Mode.</p>
      * @param string $config [optional] <p>An alternate config file to set. Used for testing.</p>
+     * @internal param string $s [optional] <p>Name for the store you want to use.
+     * This parameter is optional if only one store is defined in the config file.</p>
      */
-    public function __construct($s = null, $mock = false, $m = null, $config = null){
-        parent::__construct($s, $mock, $m, $config);
+    public function __construct($mock = false, $m = null, $config = null){
+        parent::__construct($m, $config);
         include($this->env);
         
         $this->options['Action'] = 'SubmitFeed';
@@ -293,16 +293,18 @@ class AmazonFeed extends AmazonFeedsCore{
         
         $this->log("Successfully submitted feed #".$this->response['FeedSubmissionId'].' ('.$this->response['FeedType'].')');
     }
-    
+
     /**
      * Generates array for Header.
-     * 
+     *
      * This method creates the Header array to use with cURL. It contains the Content MD5.
      * @return array
      */
     protected function genHeader(){
-        $return[0] = "Content-MD5:".$this->feedMD5;
-        return $return;
+        return [
+            "Content-Type: text/xml",
+            "Content-MD5:" . $this->feedMD5,
+        ];
     }
     
     /**
@@ -325,6 +327,14 @@ class AmazonFeed extends AmazonFeedsCore{
         }
     }
     
+    /**
+     *
+     * Returns currently set feed content
+     * @return mixed
+     */
+    public function getFeedContent(){
+        return $this->feedContent;
+    }
     
     
 }

--- a/includes/classes/AmazonFeed.php
+++ b/includes/classes/AmazonFeed.php
@@ -42,8 +42,8 @@ class AmazonFeed extends AmazonFeedsCore{
      * @internal param string $s [optional] <p>Name for the store you want to use.
      * This parameter is optional if only one store is defined in the config file.</p>
      */
-    public function __construct($mock = false, $m = null, $config = null){
-        parent::__construct($m, $config);
+    public function __construct($s = null, $mock = false, $m = null, $config = null){
+        parent::__construct($s, $mock, $m, $config);
         include($this->env);
         
         $this->options['Action'] = 'SubmitFeed';

--- a/includes/classes/AmazonShipmentItemList.php
+++ b/includes/classes/AmazonShipmentItemList.php
@@ -155,8 +155,10 @@ class AmazonShipmentItemList extends AmazonInboundCore implements Iterator{
      * @return boolean <b>FALSE</b> if something goes wrong
      */
     public function fetchItems($r = true){
-        if (!array_key_exists('ShipmentId', $this->options)){
-            $this->log("Shipment ID must be set before requesting items!",'Warning');
+        if (!array_key_exists('ShipmentId', $this->options)
+            && (!array_key_exists('LastUpdatedAfter', $this->options) && !array_key_exists('LastUpdatedBefore', $this->options))
+        ) {
+            $this->log("Shipment ID or time constraints must be set before requesting items!", 'Warning');
             return false;
         }
         


### PR DESCRIPTION
The way the params were stringified in the original repo is actually preferable, as using http_build_query the created signatures are invalid when your params have spaces or other non-url safe characters in them. I've verified this on the InboundShipments Api where I was pushing SKUs containing spaces and forward slashes. 

With the method like this it works, and with the modified version using http_build_query you either end up double-encoding or you get an invalid signature error and the call fails.

I'm using your fork in order to get the code-based marketplace configuration (great work, thanks!) but need this changed back in order to continue with it. Its a trivial change which shouldn't really affect anything else...

Cheers :)

Joe